### PR TITLE
Update the main event loop

### DIFF
--- a/README
+++ b/README
@@ -34,7 +34,7 @@ INTRODUCTION
 DEPENDENCIES
 
 	JALoP Libraries
-	audit-libs-devel >= 2.0.6
+	audit-libs-devel >= 3.0.1
 	glib2-devel
 
 BUILD STEPS

--- a/jalauditd.c
+++ b/jalauditd.c
@@ -31,6 +31,7 @@
 #include <signal.h>
 #include <libconfig.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 #include <libaudit.h>
 #include <auparse.h>
@@ -361,16 +362,21 @@ int main(void)
 		goto out;
 	}
 
+	/* Set STDIN non-blocking */
+	fcntl(0, F_SETFL, O_NONBLOCK);
+
 	au = auparse_init(AUSOURCE_FEED, 0);
 	if (!au) {
 		rc = -1;
 		syslog(LOG_ERR, "failure initializing auparse");
 		goto out;
 	}
+	auparse_set_eoe_timeout(2);
+	auparse_add_callback(au, audit_event_handle, NULL, NULL);
 
-	while (fgets_unlocked(msg, MAX_AUDIT_MESSAGE_LENGTH, stdin) && 
-		(status == RUN || status == RELOAD)) {
-
+	do {
+		fd_set read_mask;
+		int read_size = 1; /* Set to 1 so it's not EOF */
 		if (status == RELOAD || !ctx) {
 			syslog(LOG_INFO, "loading config");
 
@@ -401,7 +407,6 @@ int main(void)
 				}
 				pthread_cancel(send_ls_thread);
 			}
-			auparse_add_callback(au, audit_event_handle, ctx, NULL);
 			pthread_create(&send_ls_thread, NULL, &send_messages_to_local_store, (void*)ctx);
 			if (print_stats){
 				pthread_create(&print_stats_thread, NULL, &log_stats, NULL);
@@ -409,20 +414,39 @@ int main(void)
 
 			status = RUN;
 		}
+		do {
+			FD_ZERO(&read_mask);
+			FD_SET(0, &read_mask);
 
-		rc = auparse_feed(au, msg, strnlen(msg, MAX_AUDIT_MESSAGE_LENGTH));
-		if (rc) {
-			syslog(LOG_ERR, "failure parsing feed, rc: %d", rc);
-			goto out;
-		}
+			if (auparse_feed_has_data(au)) {
+				/* If there are any records, do a fast time
+				 * out so we can age out the data so it doesn't
+				 * get stuck inside auparse. */
+				struct timeval tv;
+				tv.tv_sec = 1;
+				tv.tv_usec = 0;
+				rc = select(1, &read_mask, NULL, NULL, &tv);
+			} else	/* no data, wait forever */
+				rc = select(1, &read_mask, NULL, NULL, NULL);
 
-		if (feof(stdin)) {
-			rc = 0;
-			break;
-		}
-	}
+			/* If we timed out & have events, shake them loose */
+			if (rc == 0 && auparse_feed_has_data(au))
+				auparse_feed_age_events(au);
 
-	rc = auparse_flush_feed(au);
+			/* The event loop */
+			if (status == RUN && rc > 0) {
+				while ((read_size = read(0, msg,
+						 MAX_AUDIT_MESSAGE_LENGTH)) > 0)
+					auparse_feed(au, msg, read_size);
+			}
+			if (read_size == 0) { /* EOF */
+				rc = 0;
+				break;
+			}
+		} while (status == RUN);
+	} while (status == RUN || status == RELOAD);
+
+	auparse_flush_feed(au);
 out:
 	jalp_context_destroy(&ctx);
 	jalp_shutdown();


### PR DESCRIPTION
The event loop was using stdio based functions which because of the
internal buffering do not work as well as just doing everything with
low level select/read loops. This improvement should let the plugin
process events faster so that auditd can move on to other things.

The auparse_set_eoe_timeout function was added in 3.0.1, so the dependencies
were updated. If compatibility with older audit libraries is needed, delete
that function and 2.5.1 should be good enough to run the new event loop.